### PR TITLE
Fix numerically negative areas leading to infinite loop in dynamic programming

### DIFF
--- a/include/Src/ConstrainedTriangulation.h
+++ b/include/Src/ConstrainedTriangulation.h
@@ -42,7 +42,7 @@ namespace MishaK
 					Point< GeometryReal , 2 > d[] = { vertices[i1]-vertices[i0] , vertices[i2]-vertices[i0] };
 					SquareMatrix< double , 2 > M;
 					for( int i=0 ; i<2 ; i++ ) for( int j=0 ; j<2 ; j++ ) M(i,j) = Point< GeometryReal , 2 >::Dot( d[i] , d[j] );
-					return M.determinant();
+					return std::max< double >( 0. , M.determinant() );
 				};
 			MinimalAreaTriangulation::GetTriangulation( SquaredArea , static_cast< unsigned int >( vertices.size() ) , outputTriangles );
 		}


### PR DESCRIPTION
I encountered some pathological situations where calls to `TriangulateConvexPolygon()` would hang forever on some very poorly conditioned inputs. The root cause of the problem seems to be `SquaredArea()` returning numerically negative `< 0` values, which cause the dynamic programming cache in `MinimalAreaTriangulation::GetTriangulation()` to blow up and get into infinite loop or exponential behavior. A simple fix is to clamp the returned values to be `>= 0`.

To reproduce the problem, you can use the following vertices as inputs to `TriangulateConvexPolygon()`:

```
0x1.94p-2,0x1.492a507f6b3adp-8
0x1.94p-2,0x1.4f1fae586e82cp-8
0x1.948p-2,0x1.5d5fa3cda476ep-8
0x1.948p-2,0x1.5a39e96a2b04ap-8
0x1.947f541877e7cp-2,0x1.5a22ffb78c7c3p-8
0x1.947cb546dae73p-2,0x1.59c99622d3989p-8
0x1.947a16753e3ddp-2,0x1.59702c8df1d04p-8
0x1.9477bf9f0d304p-2,0x1.59205b22f37fp-8
0x1.947777a3a13d7p-2,0x1.5916c2f938dbcp-8
0x1.9474d8d2048afp-2,0x1.58bd59645b585p-8
0x1.94723a0067843p-2,0x1.5863efcfa55f2p-8
0x1.946f9b2ecac76p-2,0x1.580a863accb85p-8
0x1.946d149f7acc2p-2,0x1.57b45868edc11p-8
0x1.946cfc5d2dd47p-2,0x1.57b11ca60d6ffp-8
0x1.946a5d8b90fdcp-2,0x1.5757b31140e15p-8
0x1.9467beb9f42eap-2,0x1.56fe497c70cd5p-8
0x1.94651fe8574f9p-2,0x1.56a4dfe7a8394p-8
0x1.94628116ba89ep-2,0x1.564b7652d3b27p-8
0x1.9462699fe8484p-2,0x1.564855aef6f29p-8
0x1.945fe2451dc05p-2,0x1.55f20cbe01089p-8
0x1.945d437380cd7p-2,0x1.5598a32941b78p-8
0x1.945aa4a1e40dp-2,0x1.553f39946abe7p-8
0x1.945805d0474f6p-2,0x1.54e5cfff9277cp-8
0x1.9457bea055f8p-2,0x1.54dc52f4e7e23p-8
0x1.945566feaa595p-2,0x1.548c666ad49d7p-8
0x1.9452c82d0d6c9p-2,0x1.5432fcd612748p-8
0x1.9450295b70cb2p-2,0x1.53d993412cf48p-8
0x1.944d8a89d3debp-2,0x1.538029ac6aa33p-8
0x1.944d13a0c38ap-2,0x1.5370503ae6d36p-8
0x1.944aebb83716dp-2,0x1.5326c0179729fp-8
0x1.94484ce69a252p-2,0x1.52cd5682d74d6p-8
0x1.9445ae14fd489p-2,0x1.5273ecee0d7dap-8
0x1.94430f4360929p-2,0x1.521a835931a14p-8
0x1.944268a131294p-2,0x1.52044d80df7c7p-8
0x1.94407071c38f9p-2,0x1.51c119c479ea7p-8
0x1.943dd1a026b96p-2,0x1.5167b02fad194p-8
0x1.943b32ce89dc8p-2,0x1.510e469ae3844p-8
0x1.943893fced281p-2,0x1.50b4dd0606e59p-8
0x1.9437bda19eda8p-2,0x1.50984ac6cfc24p-8
0x1.9435f52b503b2p-2,0x1.505b737144d26p-8
0x1.94335659b380cp-2,0x1.500209dc6afefp-8
0x1.9430b788168c4p-2,0x1.4fa8a047ac7c8p-8
0x1.942e18b679c32p-2,0x1.4f4f36b2d98fp-8
0x1.942d12a20c741p-2,0x1.4f2c480ccb1cfp-8
0x1.942b79e4dd01fp-2,0x1.4ef5cd1e02f1ep-8
0x1.9428db133ff43p-2,0x1.4e9c638950413p-8
0x1.94263c41a3221p-2,0x1.4e42f9f481962p-8
0x1.94239d7006489p-2,0x1.4de9905fb65cfp-8
0x1.942267a27a09fp-2,0x1.4dc04552c8358p-8
0x1.9420fe9e69a5dp-2,0x1.4d9026cad17a6p-8
0x1.941e5fccccc52p-2,0x1.4d36bd3609a7ep-8
0x1.941bc0fb2fdc9p-2,0x1.4cdd53a1457adp-8
0x1.9419222992ea6p-2,0x1.4c83ea0c85d5dp-8
0x1.9417bca2e784ap-2,0x1.4c544298d20f6p-8
0x1.94168357f62e9p-2,0x1.4c2a8077acbbbp-8
0x1.9413e486593e7p-2,0x1.4bd116e2ec219p-8
0x1.941145b4bc7e8p-2,0x1.4b77ad4e14eabp-8
0x1.940ea6e31faefp-2,0x1.4b1e43b94510ep-8
0x1.940d11a3553eep-2,0x1.4ae83fdebe156p-8
0x1.940c081182c51p-2,0x1.4ac4da2481843p-8
0x1.9409693fe5fd3p-2,0x1.4a6b708fae0cp-8
0x1.9406ca6e4924dp-2,0x1.4a1206fae249dp-8
0x1.94042b9cac2dcp-2,0x1.49b89d6624f48p-8
0x1.940266a3c2c1p-2,0x1.497c3d24c46fp-8
0x1.94018ccb0f5b8p-2,0x1.495f33d15653ap-8
```